### PR TITLE
Added RealUserStatus

### DIFF
--- a/token.go
+++ b/token.go
@@ -27,6 +27,7 @@ type JWTTokenBody struct {
 	Email          string `json:"email"`
 	EmailVerified  string `json:"email_verified"`
 	IsPrivateEmail string `json:"is_private_email"`
+	RealUserStatus int64  `json:"real_user_status"`
 	AuthTime       int64  `json:"auth_time"`
 	Nonce          string `json:"nonce"`
 }


### PR DESCRIPTION
`real_user_status`
An Integer value that indicates whether the user appears to be a real person. Use the value of this claim to mitigate fraud. The possible values are: 0 (or Unsupported), 1 (or Unknown), 2 (or LikelyReal). For more information, see ASUserDetectionStatus. This claim is present only on iOS 14 and later, macOS 11 and later, watchOS 7 and later, tvOS 14 and later; the claim isn’t present or supported for web-based apps.