### PR TITLE
Split secret generation and token exchange

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,12 +18,19 @@ Get the tokens from Apple in the following three steps:
     - Using file: `siwagoObj.SetSecretP8File("/etc/keys/AuthKey_3UHT5POLK9.p8")`
     - Using file contents as string: `siwagoObj.SetSecretP8String("//-----BEGIN PRIVATE KEY-----\njkfweshjdjkhjsbjvguybjebvuewkvbbhj+jbdhbjhbvjhbvjhbvbjvbvjvagcve\njkfweshjdjkhjsbjvguybje/vuewkvbbhjdjbdhbjhbvjhbvjhbvbjvbvjvagcve\njkfweshjdjkhjsbjvguybjebvuewkvbbhj+jbdhbjhbvjhbvjhbvbjvbvjvagcve\njkfweshj\n-----END PRIVATE KEY-----")`
     - Using file contents as []byte: `siwagoObj.SetSecretP8Bytes(byteContents)`
-3. Exchange the code for a token `token:=siwagoObj.ExchangeAuthCode(code, redirectUri)` `redirectUri` can be `""` if it does not apply
+3. Exchange the code for a token `token, err :=siwagoObj.ExchangeAuthCode(code, redirectUri)` `redirectUri` can be `""` if it does not apply
+
+Alternatively, you can split the secret generation and token steps as follows:
+1. Initialize the SiwaConfig object `siwago.GetObject(KID, TEAMID, BUNDLEID, duration, "")`.
+2. Generate a secret key: `secret, err := siwagoObj.GetClientSecret()`.
+3. (Possibly in a separate process) initialize a new SiwaConfig with just the
+   client secret: `siwago.GetObjectWithSecret(BUNDLEID, nonce, secret)`.
+4. Token exchange: `token, err :=siwagoObj.ExchangeAuthCode(code, redirectUri)`
 
 
 If there is an error `token.Error` is set to the error recieved from Apple. More info: https://developer.apple.com/documentation/signinwithapplerestapi/errorresponse 
 
-In case of success token object is populated with the access token, refresh token, etc. from apple. More info: https://developer.apple.com/documentation/signinwithapplerestapi/tokenresponse
+In case of success token object is populated with the access token, refresh token, etc. from Apple. More info: https://developer.apple.com/documentation/signinwithapplerestapi/tokenresponse
 
 ## Details
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pagnihotry/siwago
+
+go 1.17

--- a/siwaconfig.go
+++ b/siwaconfig.go
@@ -265,11 +265,6 @@ func (self *SiwaConfig) validateWithApple(code string, codeType string, redirect
 		return nil, errors.New(fmt.Sprintf("codeType can be %v or %v. %v recieved", AUTHORIZATION_CODE, REFRESH_TOKEN, codeType))
 	}
 
-	//check if siwa object is valid, all required values have been set
-	if _, err = self.ValidateForTokenExchange(); err != nil {
-		return nil, err
-	}
-
 	var err error
 	var clientSecret string
 	var form url.Values
@@ -280,6 +275,11 @@ func (self *SiwaConfig) validateWithApple(code string, codeType string, redirect
 	var tok Token
 	var reason string
 	var siwaIdToken *SiwaIdToken
+
+	//check if siwa object is valid, all required values have been set
+	if _, err = self.ValidateForTokenExchange(); err != nil {
+		return nil, err
+	}
 
 	//gather form values for post
 	clientSecret = self.ClientSecret

--- a/siwaconfig.go
+++ b/siwaconfig.go
@@ -258,14 +258,15 @@ func (self *SiwaConfig) validateWithApple(code string, codeType string, redirect
 	var reason string
 	var siwaIdToken *SiwaIdToken
 
-	//check if siwa object is valid, all required values have been set
-	if _, err = self.ValidateObject(); err != nil {
-		return nil, err
-	}
-
 	//gather form values for post
 	clientSecret = self.ClientSecret
 	if clientSecret == "" {
+		// TODO: split this into validate for signing/validate for exchange
+		//check if siwa object is valid, all required values have been set
+		if _, err = self.ValidateObject(); err != nil {
+			return nil, err
+		}
+
 		clientSecret, err = self.GetClientSecret()
 		if err != nil {
 			return nil, errors.New("Error while generating client_secret. " + err.Error())


### PR DESCRIPTION
Apple recommends generating the client secret offline and not storing your private key on the server, so tweak this library to support doing the secret generation and token exchange steps separately. Existing usage does not change. Also adds a go.mod file (closes #4).